### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,11 +1,13 @@
 Introduction
 ============
 
-hacking is a set of flake8 plugins that test and enforce the :ref:`StyleGuide`.
+hacking is a set of flake8 plugins that test and enforce the `StyleGuide`_.
 
 Hacking pins its dependencies, as a new release of some dependency can break
 hacking based gating jobs. This is because new versions of dependencies can
 introduce new rules, or make existing rules stricter.
+
+.. _`StyleGuide`: http://docs.openstack.org/developer/hacking/#openstack-style-guidelines
 
 Installation
 ============
@@ -76,9 +78,8 @@ Requirements
 ------------
 - The check must already have community support. We do not want to dictate
   style, only enforce it.
-- The canonical source of the OpenStack Style Guidelines is :ref:`StyleGuide`,
-  and hacking just enforces
-  them; so when adding a new check, it must be in ``HACKING.rst``
+- The `StyleGuide`_ is the canonical source of the OpenStack Style; hacking just enforces them. 
+  When adding a new check, it must be in ``HACKING.rst``.
 - False negatives are ok, but false positives are not
 - Cannot be project specific, project specific checks should be `Local Checks`_
 - Include extensive tests


### PR DESCRIPTION
-- edited rst markup to correct broken links to OpenStack Style Guide

I'm submitting this via GitHub and not in Gerrit because it's for the README for this repo.